### PR TITLE
Kinematic calculation functions

### DIFF
--- a/Exclusive/README.md
+++ b/Exclusive/README.md
@@ -1,3 +1,20 @@
 # snippets/Exclusive
 
 Snippets related to exclusive, diffractive, and tagged processes at the EIC.
+
+## `ePIC_ExcKinUtils.h`
+
+This is a header file which contains functions for calculating exclusive kinematic quantities. In order to use these functions within any ePIC analysis, the following line should be added to the relevant scripts:
+
+```
+#include "snippets/Exclusive/ePIC_ExcKinUtils.h"
+```
+
+The header file here contains functions for calculating the following quantities:
+- The energy of a particle, from its scalar mass and vector momentum.
+- Missing mass (squared), momentum, pT and energy, for a 2-body final state (a + b -> c + d)
+- Missing mass (squared), momentum, pT and energy, for a 3-body final state (a + b -> c + d + f)
+- The Mandelstam variable t, using multiple methods as defined in the tRECO convention note  **STILL IN PROGRESS**
+
+
+The functions take as input the 4 vectors for particles identified within an ePIC event. These 4-vectors can take the form of any type which includes the relevant operators: `.E()`, `.P()`, `.Pt()` and `.M2()`. ROOT's legacy `TLorentzVector` class, and its more recent replacement, `ROOT::Math::LorentzVector`, both contain all of the operators required.

--- a/Exclusive/ePIC_ExcKinUtils.h
+++ b/Exclusive/ePIC_ExcKinUtils.h
@@ -1,0 +1,216 @@
+//---------------------------------------------------------------------------------------
+//
+// Utility functions; calculation of kinematic quantities for exclusive ePIC analyses
+//
+// Author: O. Jevons, 27/02/25
+//
+//---------------------------------------------------------------------------------------
+
+#include "TMath.h"
+
+// Aliases for common 3/4-vector types
+using P3EVector=ROOT::Math::PxPyPzEVector;
+using P3MVector=ROOT::Math::PxPyPzMVector;
+using MomVector=ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double_t>,ROOT::Math::DefaultCoordinateSystemTag>;
+
+//-----------------------------------------------------------------------------------------------------------------------------
+// FUNCTION DEFINITIONS
+//
+// NOTE: Templating applied for brevity
+//       4-vector functions are valid for any type which contains the operators E(), P(), Pt() and M2()
+//       This includes TLorentzVector (legacy) and ALL variants of ROOT::Math::LorentzVector class
+//
+//-----------------------------------------------------------------------------------------------------------------------------
+
+
+//-----------------------------------------------------------------------------------------------------------------------------
+// FUNCTION DEFINITIONS
+//-----------------------------------------------------------------------------------------------------------------------------
+
+// Calculate energy from momentum and mass
+// 1. Using vector structures for momentum
+// Works for ANY structure which contains Mag2() operator
+template<typename P>
+Double_t calcE(const P& mom, const Float_t& M){ 
+  return TMath::Sqrt(mom.Mag2() + TMath::Power(M,2)); 
+}
+// 2. Using separate floats for momentum components
+Double_t calcE(const Float_t& px, const Float_t& py, const Float_t& pz, const Float_t& M){ 
+  return TMath::Sqrt(TMath::Power(px,2) + TMath::Power(py,2) + TMath::Power(pz,2) + TMath::Power(M,2)); 
+}
+
+
+// Calculate Mandelstam t - BABE method using tRECO conventions
+// Uses incoming proton BEam and scattered BAryon 4-vectors
+// Another way of saying t = -(p' - p)^2
+//--------------------------------------------------------------
+// NEEDS: p, p'
+//--------------------------------------------------------------
+template <typename V>
+Double_t calcT_BABE(const V& be, const V& ba){
+  double t = (ba - be).M2();
+  
+  return TMath::Abs(t);
+}
+
+// Calculate Mandelstam t - eX method using tRECO conventions
+// Uses difference between the beam and scattered electron and all of the (non-scattered) final state
+// e.g. for DVCS, X is a photon; for electroproduction, it is the species of interest; etc...
+//--------------------------------------------------------------
+// NEEDS: e, e', X   [q, X]
+//--------------------------------------------------------------
+// 1. Separate vectors for beam and scattered electrons
+template <typename V>
+Double_t calcT_eX(const V& e, const V& ep, const V& X){
+  double t = (e - ep - X).M2();
+  return TMath::Abs(t);
+}
+// 2. Giving virtual photon vector directly
+template <typename V>
+Double_t calcT_eX(const V& q, const V& X){
+  double t = (q - X).M2();
+  return TMath::Abs(t);
+}
+
+// Calculate Mandelstam t - eXBA method using tRECO conventions
+// Include final state baryon information into eX method
+//--------------------------------------------------------------
+// NEEDS: e, e', p', X    [e, e', HFS]
+// CANNOT JUST GIVE q-VECTOR; NEED INFO. FROM e'
+//--------------------------------------------------------------
+// 1. Providing separate vectors for all particles
+template <typename V>
+Double_t calcT_eXBA(const V& e, const V& ep, const V& pp, const V& X){
+  // Extract info. from vectors - e' energy and theta
+  double E_ep = ep.E();
+  double theta_ep = ep.Theta();
+
+  // Intermediate calculations - q vector and HFS sigma
+  P3EVector q(e.X()-ep.X(), e.Y()-ep.Y(), e.Z()-ep.Z(), e.E()-ep.E());
+  double sigma_h = (pp+X).E() - (pp+X).Z();
+  double sigterm = sigma_h/2;
+  double eterm = (E_ep*(1+TMath::Cos(theta_ep)))/2;
+  
+  P3EVector pcorr(q.X(), q.Y(), -sigterm-eterm, sigterm-eterm);
+  
+  double t = (pcorr - X).M2();
+  return TMath::Abs(t);
+}
+// 2. Combining HFS into 1 vector
+template <typename V>
+Double_t calcT_eXBA(const V& e, const V& ep, const V& HFS){
+  // Extract info. from vectors - e' energy and theta
+  double E_ep = ep.E();
+  double theta_ep = ep.Theta();
+
+  // Intermediate calculations - q vector and HFS sigma
+  P3EVector q(e.X()-ep.X(), e.Y()-ep.Y(), e.Z()-ep.Z(), e.E()-ep.E());
+  double sigma_h = (HFS.E() - HFS.Z());
+  double sigterm = sigma_h/2;
+  double eterm = (E_ep*(1+TMath::Cos(theta_ep)))/2;
+  
+  P3EVector pcorr(q.X(), q.Y(), -sigterm-eterm, sigterm-eterm);
+
+  double t = (pcorr - X).M2();
+  return TMath::Abs(t);
+}
+
+// Calculate Mandelstam t - eXBE method using tRECO conventions
+// Include initial beam proton information into eX method
+//--------------------------------------------------------------
+// NEEDS: TO CHECK
+//--------------------------------------------------------------
+
+// Calculate Mandelstam t - eBABE method using tRECO conventions
+// Include electron (beam and scattered) information into BABE method
+//--------------------------------------------------------------
+// NEEDS: e, p, ep, pp    [q, p, pp]
+//--------------------------------------------------------------
+// 1. Separate vectors for beam and scattered electrons
+template<typename V>
+Double_t calcT_eBABE(const V& e, const V& p, const V& ep, const V& pp){
+  // Calculate needed vectors
+  P3EVector q(e.X()-ep.X(), e.Y()-ep.Y(), e.Z()-ep.Z(), e.E()-ep.E());
+  P3EVector pcorr(-q.X(), -q.Y() pp.Z(), pp.E());
+
+  double t = (pcorr - p).M2();
+  return TMath::Abs(t);
+}
+// 2. Giving virtual photon vector directly
+template <typename V>
+Double_t calcT_eBABE(const V& p, const V& q, const V& pp){
+  P3EVector pcorr(-q.X(), -q.Y() pp.Z(), pp.E());
+
+  double t = (pcorr - p).M2();
+  return TMath::Abs(t);
+}
+
+// Calculate Mandelstam t - XBABE method using tRECO conventions
+// Includes further final state information into BABE method
+//--------------------------------------------------------------
+// NEEDS: p, pp, X
+// CANNOT PROVIDE HFS BY ITSELF
+//--------------------------------------------------------------
+template<typename V>
+Double_t calcT_eBABE(const V& p, const V& pp, const V& X){
+  P3EVector pcorr(-X.X(), -X.Y(), pp.Z(), pp.E());
+
+  double t = (pcorr - p).M2();
+  return TMath::Abs(t);
+}
+
+// Calculate Mandelstam t - eXBABE method using tRECO conventions
+// Uses full event information
+
+// Calculate missing kinematics (mass/energy/momentum)
+// 3-body final state: ab->cdf
+// Missing momentum
+template <typename V>
+Double_t calcPMiss_3Body(const V& a, const V& b, const V& c, const V& d, const V& f){ 
+  return (a+b-c-d-f).P(); 
+}
+// Missing transverse momentum
+template <typename V>
+Double_t calcPtMiss_3Body(const V& a, const V& b, const V& c, const V& d, const V& f){
+  return (a+b-c-d-f).Pt(); 
+}
+// Missing energy
+template <typename V>
+Double_t calcEMiss_3Body(const V& a, const V& b, const V& c, const V& d, const V& f){
+  return (a+b-c-d-f).E(); 
+}
+// Missing mass (squared)
+template <typename V>
+Double_t calcM2Miss_3Body(const V& a, const V& b, const V& c, const V& d, const V& f){
+  Float_t fEMiss = (a+b-c-d-f).E();
+  Float_t fPMiss = (a+b-c-d-f).P();
+
+  Float_t fM2Miss = TMath::Power(fEMiss,2) - TMath::Power(fPMiss,2);
+  return fM2Miss;
+}
+
+// 2-body final state: ab->cd
+// Missing momentum
+template <typename V>
+Double_t calcPMiss_2Body(const V& a, const V& b, const V& c, const V& d){
+  return (a+b-c-d).P();
+}
+// Missing transverse momentum
+template <typename V>
+Double_t calcPtMiss_2Body(const V& a, const V& b, const V& c, const V& d){
+  return (a+b-c-d).Pt();
+}
+// Missing energy
+template <typename V>
+Double_t calcEMiss_2Body(const V& a, const V& b, const V& c, const V& d){
+  return (a+b-c-d).E();
+}
+// Missing mass (squared)
+template <typename V>
+Double_t calcM2Miss_2Body(const V& a, const V& b, const V& c, const V& d){
+  Float_t fEMiss = (a+b-c-d).E();
+  Float_t fPMiss = (a+b-c-d).P();
+
+  Float_t fM2Miss = TMath::Power(fEMiss,2) - TMath::Power(fPMiss,2);
+  return fM2Miss;
+}

--- a/Inclusive/README.md
+++ b/Inclusive/README.md
@@ -1,3 +1,18 @@
 # snippets/Inclusive
 
 Snippets related to inclusive processes at the EIC.
+
+## `ePIC_IncKinUtils.h`
+
+This is a header file which contains functions for calculating inclusive kinematic quantities by hand. In order to use these functions within any ePIC analysis, the following line should be added to the relevant scripts:
+
+```
+#include "snippets/Inclusive/ePIC_IncKinUtils.h"
+```
+
+The header file here duplicates the effects of the `InclusiveKinematics` branches within the output trees created by `EICrecon`, for those who wish to calculate Q2, x and y by hand. Functions are included for the following:
+- Caclulating Q2, x and y separately.
+- Calculating all three quantities simultaneously, and storing them in holding variables passed to the function.
+- All of the above for all methods used for the calculation of the `InclusiveKinematics` branches (Electron, Jaquet-Blondel, Double Angle, Sigma and e-Sigma).
+
+The functions take as input the 4 vectors for particles identified within an ePIC event. These 4-vectors can take the form of any type which includes the relevant operators: `.X()`, `.Y()`, `.Z()`, `.E()`, `.Pt()`, `.M2()` and `.Dot()`. ROOT's legacy `TLorentzVector` class, and its more recent replacement, `ROOT::Math::LorentzVector`, both contain all of the operators required.

--- a/Inclusive/ePIC_IncKinUtils.h
+++ b/Inclusive/ePIC_IncKinUtils.h
@@ -1,0 +1,657 @@
+//---------------------------------------------------------------------------------------
+//
+// Utility functions; calculation of kinematic quantities for inclusive ePIC analyses
+//
+// Q2, x and y for all 5 methods used for the InclusiveKinematics branch of EICrecon
+//     - Electron, JB, DA, Sigma and eSigma
+//
+// Author: O. Jevons, 27/02/25
+//
+//---------------------------------------------------------------------------------------
+
+#include "TMath.h"
+
+// Aliases for common 3/4-vector types
+using P3EVector=ROOT::Math::PxPyPzEVector;
+using P3MVector=ROOT::Math::PxPyPzMVector;
+using MomVector=ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double_t>,ROOT::Math::DefaultCoordinateSystemTag>;
+
+//-----------------------------------------------------------------------------------------------------------------------------
+// FUNCTION DEFINITIONS
+//
+// NOTE: Templating applied for brevity
+//       Functions are valid for any type which contains the operators X(), Y(), Z(), E(), Pt(), M2() and Dot()
+//       This includes TLorentzVector (legacy) and ALL variants of ROOT::Math::LorentzVector class
+//
+//
+// NOTE 2: Order of vectors (whichever are required) is ALWAYS as follows (for process ep -> e'p'X - change scattered baryon as necessary)
+//
+//         e -> p -> e' -> p' -> X
+//
+//-----------------------------------------------------------------------------------------------------------------------------
+
+// Calculate DIS kinematics - electron method
+// e + p -> e' + X
+// Q2
+template <typename V>
+Double_t calcQ2_Elec(const V& e, const V& ep){
+  return -(e-ep).M2();
+}
+// x
+template <typename V>
+Double_t calcX_Elec(const V& e, const V& p, const V& ep){
+  P3EVector q(e.X()-ep.X(), e.Y()-ep.Y(), e.Z()-ep.Z(), e.E()-ep.E());
+  Double_t q2 = -q.Dot(q);
+  Double_t den = 2*q.Dot(p);
+
+  return q2/den;
+}
+// y
+template <typename V>
+Double_t calcY_Elec(const V& e, const V& p, const V& ep){
+  P3EVector q(e.X()-ep.X(), e.Y()-ep.Y(), e.Z()-ep.Z(), e.E()-ep.E());
+  Double_t num = p.Dot(q);
+  Double_t den = p.Dot(e);
+  
+  return num/den;
+}
+// Calculate all 3 kinematic variables (Q2, x, y) simultaneously and pass them to holding variables
+template <typename V>
+void calcKin_Elec(const V& e, const V& p, const V& ep, Float_t &Q2, Float_t &x, Float_t &y){
+  // Reset kinematic variables
+  Q2 = 0;
+  x = 0;
+  y = 0;
+
+  // Calculate kinematics
+  P3EVector q(e.X()-ep.X(), e.Y()-ep.Y(), e.Z()-ep.Z(), e.E()-ep.E());
+  Float_t Q2_e = -q.Dot(q);
+  
+  Float_t q_dot_p = q.Dot(p);
+  Float_t x_e = Q2_e/(2*q_dot_p);
+
+  Float_t e_dot_p = e.Dot(p);
+  Float_t y_e = q_dot_p/e_dot_p;
+
+  // Export variables
+  Q2 = Q2_e;
+  x = x_e;
+  y = y_e;
+}
+
+// Calculate inclusive kinematics (Q2, x, y) with the JB method
+// SIDIS case ep -> e'p'X
+// Q2
+template <typename V>
+Double_t calcQ2_JB(const V& e, const V& pp, const V& X){
+  // Intermediate variables
+  Float_t pT2_h = TMath::Power((pp+X).X(),2) + TMath::Power((pp+X).Y(),2);
+  Float_t sigma_h = (pp+X).E() - (pp+X).Z();
+  
+  // Kinematic variables
+  Float_t y_jb = sigma_h / (2*e.E());
+  Float_t Q2_jb = pT2_h / (1-y_jb);
+
+  return Q2_jb;
+}
+// x
+template <typename V>
+Double_t calcX_JB(const V& e, const V& p, const V& pp, const V& X){
+  // Intermediate variables
+  Float_t pT2_h = TMath::Power((pp+X).X(),2) + TMath::Power((pp+X).Y(),2);
+  Float_t sigma_h = (pp+X).E() - (pp+X).Z();
+  
+  // Kinematic variables
+  Float_t y_jb = sigma_h / (2*e.E());
+  Float_t Q2_jb = pT2_h / (1-y_jb);
+  Float_t x_jb = Q2_jb / (4*e.E()*p.E()*y_jb);
+  
+  return x_jb;
+}
+// y
+template <typename V>
+Double_t calcY_JB(const V& e, const V& pp, const V& X){
+  // Intermediate variables
+  Float_t pT2_h = TMath::Power((pp+X).X(),2) + TMath::Power((pp+X).Y(),2);
+  Float_t sigma_h = (pp+X).E() - (pp+X).Z();
+
+  // Kinematic variables
+  Float_t y_jb = sigma_h / (2*e.E());
+
+  return y_jb;
+}
+// Calculate all 3 kinematic variables (Q2, x, y) simultaneously and pass them to holding variables 
+template <typename V>
+void calcKin_JB(const V& e, const V& p, const V& pp, const V& X, Float_t &Q2, Float_t &x, Float_t &y){
+  // Reset kinematic variables
+  Q2 = 0;
+  x = 0;
+  y = 0;
+  
+  // Intermediate variables
+  Float_t pT2_h = TMath::Power((pp+X).X(),2) + TMath::Power((pp+X).Y(),2);
+  Float_t sigma_h = (pp+X).E() - (pp+X).Z();
+  
+  // Kinematic variables
+  Float_t y_jb = sigma_h / (2*e.E());
+  Float_t Q2_jb = pT2_h / (1-y_jb);
+  Float_t x_jb = Q2_jb / (4*e.E()*p.E()*y_jb);
+  
+  // Export kinematic variables
+  Q2 = Q2_jb;
+  x = x_jb;
+  y = y_jb;
+}
+
+// DIS case ep -> e'X
+// Q2
+template <typename V>
+Double_t calcQ2_JB(const V& e, const V& HFS){
+  // Intermediate variables
+  Float_t pT2_h = TMath::Power(HFS.X(),2) + TMath::Power(HFS.Y(),2);
+  Float_t sigma_h = HFS.E() - HFS.Z();
+  
+  // Kinematic variables
+  Float_t y_jb = sigma_h / (2*e.E());
+  Float_t Q2_jb = pT2_h / (1-y_jb);
+
+  return Q2_jb;
+}
+// x
+template <typename V>
+Double_t calcX_JB(const V& e, const V& p, const V& HFS){
+  // Intermediate variables
+  Float_t pT2_h = TMath::Power(HFS.X(),2) + TMath::Power(HFS.Y(),2);
+  Float_t sigma_h = HFS.E() - HFS.Z();
+  
+  // Kinematic variables
+  Float_t y_jb = sigma_h / (2*e.E());
+  Float_t Q2_jb = pT2_h / (1-y_jb);
+  Float_t x_jb = Q2_jb / (4*e.E()*p.E()*y_jb);
+  
+  return x_jb;
+}
+// y
+template <typename V>
+Double_t calcY_JB(const V& e, const V& HFS){
+  // Intermediate variables
+  Float_t sigma_h = HFS.E() - HFS.Z();
+  
+  // Kinematic variables
+  Float_t y_jb = sigma_h / (2*e.E());
+
+  return y_jb;
+}
+// Calculate all 3 kinematic variables (Q2, x, y) simultaneously and pass them to holding variables 
+template <typename V>
+void calcKin_JB(const V& e, const V& p, const V& HFS, Float_t &Q2, Float_t &x, Float_t &y){
+  // Reset kinematic variables
+  Q2 = 0;
+  x = 0;
+  y = 0;
+  
+  // Intermediate variables
+  Float_t pT2_h = TMath::Power(HFS.X(),2) + TMath::Power(HFS.Y(),2);
+  Float_t sigma_h = HFS.E() - HFS.Z();
+  
+  // Kinematic variables
+  Float_t y_jb = sigma_h / (2*e.E());
+  Float_t Q2_jb = pT2_h / (1-y_jb);
+  Float_t x_jb = Q2_jb / (4*e.E()*p.E()*y_jb);
+  
+  // Export kinematic variables
+  Q2 = Q2_jb;
+  x = x_jb;
+  y = y_jb;
+}
+
+// Calculate inclusive kinematics (Q2, x, y) with the DA method
+// SIDIS case ep -> e'p'X
+// Q2
+template <typename V>
+Double_t calcQ2_DA(const V& e, const V& ep, const V& pp, const V& X){
+  // Intermediate variables
+  Float_t pT2_h = TMath::Power((pp+X).X(),2) + TMath::Power((pp+X).Y(),2);
+  Float_t sigma_h = (pp+X).E() - (pp+X).Z();
+  Float_t S2_h = sigma_h*sigma_h;
+  Float_t gamma = TMath::ACos((pT2_h-S2_h)/(pT2_h+S2_h));
+  
+  // Kinematic variables
+  Float_t Q2_da = 4*e.E()*e.E()*(1./TMath::Tan(ep.Theta()/2))*(1./(TMath::Tan(ep.Theta()/2) +  TMath::Tan(gamma/2)));
+
+  return Q2_da;
+}
+// x
+template <typename V>
+Double_t calcX_DA(const V& e, const V& p, const V& ep, const V& pp, const V& X){
+  // Intermediate variables
+  Float_t pT2_h = TMath::Power((pp+X).X(),2) + TMath::Power((pp+X).Y(),2);
+  Float_t sigma_h = (pp+X).E() - (pp+X).Z();
+  Float_t S2_h = sigma_h*sigma_h;
+  Float_t gamma = TMath::ACos((pT2_h-S2_h)/(pT2_h+S2_h));
+  
+  // Kinematic variables
+  Float_t y_da = TMath::Tan(gamma/2) / (TMath::Tan(ep.Theta()/2) +  TMath::Tan(gamma/2));
+  Float_t Q2_da = 4*e.E()*e.E()*(1./TMath::Tan(ep.Theta()/2))*(1./(TMath::Tan(ep.Theta()/2) +  TMath::Tan(gamma/2)));
+  Float_t x_da = Q2_da/(4*e.E()*p.E()*y_da);
+
+  return x_da;
+}
+// y
+template <typename V>
+Double_t calcY_DA(const V& ep, const V& pp, const V& X){
+  // Intermediate variables
+  Float_t pT2_h = TMath::Power((pp+X).X(),2) + TMath::Power((pp+X).Y(),2);
+  Float_t sigma_h = (pp+X).E() - (pp+X).Z();
+  Float_t S2_h = sigma_h*sigma_h;
+  Float_t gamma = TMath::ACos((pT2_h-S2_h)/(pT2_h+S2_h));
+  
+  // Kinematic variables
+  Float_t y_da = TMath::Tan(gamma/2) / (TMath::Tan(ep.Theta()/2) +  TMath::Tan(gamma/2));
+
+  return y_da;
+}
+// Calculate all 3 kinematic variables (Q2, x, y) simultaneously and pass them to holding variables 
+template <typename V>
+void calcKin_DA(const V& e, const V& p, const V& ep, const V& pp, const V& X, Float_t &Q2, Float_t &x, Float_t &y){
+  // Reset kinematic variables
+  Q2 = 0;
+  x = 0;
+  y = 0;
+ 
+  // Calculate intermediate quantities
+  // Intermediate variables
+  Float_t pT2_h = TMath::Power((pp+X).X(),2) + TMath::Power((pp+X).Y(),2);
+  Float_t sigma_h = (pp+X).E() - (pp+X).Z();
+  Float_t S2_h = sigma_h*sigma_h;
+  Float_t gamma = TMath::ACos((pT2_h-S2_h)/(pT2_h+S2_h));
+  
+  // Kinematic variables
+  Float_t y_da = TMath::Tan(gamma/2) / (TMath::Tan(ep.Theta()/2) +  TMath::Tan(gamma/2));
+  Float_t Q2_da = 4*e.E()*e.E()*(1./TMath::Tan(ep.Theta()/2))*(1./(TMath::Tan(ep.Theta()/2) +  TMath::Tan(gamma/2)));
+  Float_t x_da = Q2_da/(4*e.E()*p.E()*y_da);
+
+  // Export kinematic variables
+  Q2 = Q2_da;
+  x = x_da;
+  y = y_da;
+}
+
+// DIS case ep -> e'X
+// Q2
+template <typename V>
+Double_t calcQ2_DA(const V& e, const V& ep, const V& HFS){
+  // Intermediate variables
+  Float_t pT2_h = TMath::Power(HFS.X(),2) + TMath::Power(HFS.Y(),2);
+  Float_t sigma_h = HFS.E() - HFS.Z();
+  Float_t S2_h = sigma_h*sigma_h;
+  Float_t gamma = TMath::ACos((pT2_h-S2_h)/(pT2_h+S2_h));
+  
+  // Kinematic variables
+  Float_t Q2_da = 4*e.E()*e.E()*(1./TMath::Tan(ep.Theta()/2))*(1./(TMath::Tan(ep.Theta()/2) +  TMath::Tan(gamma/2)));
+
+  return Q2_da;
+}
+// x
+template <typename V>
+Double_t calcX_DA(const V& e, const V& p, const V& ep, const V& HFS){
+  // Intermediate variables
+  Float_t pT2_h = TMath::Power(HFS.X(),2) + TMath::Power(HFS.Y(),2);
+  Float_t sigma_h = HFS.E() - HFS.Z();
+  Float_t S2_h = sigma_h*sigma_h;
+  Float_t gamma = TMath::ACos((pT2_h-S2_h)/(pT2_h+S2_h));
+  
+  // Kinematic variables
+  Float_t y_da = TMath::Tan(gamma/2) / (TMath::Tan(ep.Theta()/2) +  TMath::Tan(gamma/2));
+  Float_t Q2_da = 4*e.E()*e.E()*(1./TMath::Tan(ep.Theta()/2))*(1./(TMath::Tan(ep.Theta()/2) +  TMath::Tan(gamma/2)));
+  Float_t x_da = Q2_da/(4*e.E()*p.E()*y_da);
+
+  return x_da;
+}
+// y
+template <typename V>
+Double_t calcY_DA(const V& ep, const V& HFS){
+  // Intermediate variables
+  Float_t pT2_h = TMath::Power(HFS.X(),2) + TMath::Power(HFS.Y(),2);
+  Float_t sigma_h = HFS.E() - HFS.Z();
+  Float_t S2_h = sigma_h*sigma_h;
+  Float_t gamma = TMath::ACos((pT2_h-S2_h)/(pT2_h+S2_h));
+  
+  // Kinematic variables
+  Float_t y_da = TMath::Tan(gamma/2) / (TMath::Tan(ep.Theta()/2) +  TMath::Tan(gamma/2));
+
+  return y_da;
+}
+// Calculate all 3 kinematic variables (Q2, x, y) simultaneously and pass them to holding variables 
+template <typename V>
+void calcKin_DA(const V& e, const V& p, const V& ep, const V& HFS, Float_t &Q2, Float_t &x, Float_t &y){
+  // Reset kinematic variables
+  Q2 = 0;
+  x = 0;
+  y = 0;
+ 
+  // Calculate intermediate quantities
+  // Intermediate variables
+  Float_t pT2_h = TMath::Power(HFS.X(),2) + TMath::Power(HFS.Y(),2);
+  Float_t sigma_h = HFS.E() - HFS.Z();
+  Float_t S2_h = sigma_h*sigma_h;
+  Float_t gamma = TMath::ACos((pT2_h-S2_h)/(pT2_h+S2_h));
+  
+  // Kinematic variables
+  Float_t y_da = TMath::Tan(gamma/2) / (TMath::Tan(ep.Theta()/2) +  TMath::Tan(gamma/2));
+  Float_t Q2_da = 4*e.E()*e.E()*(1./TMath::Tan(ep.Theta()/2))*(1./(TMath::Tan(ep.Theta()/2) +  TMath::Tan(gamma/2)));
+  Float_t x_da = Q2_da/(4*e.E()*p.E()*y_da);
+
+  // Export kinematic variables
+  Q2 = Q2_da;
+  x = x_da;
+  y = y_da;
+}
+
+// Calculate inclusive kinematics (Q2, x, y) with the Sigma method
+// SIDIS case ep -> e'p'X
+// Q2
+template <typename V>
+Double_t calcQ2_Sigma(const V& ep, const V& pp, const V& X){
+  // Intermediate variables
+  Float_t pT2_h = TMath::Power((pp+X).X(),2) + TMath::Power((pp+X).Y(),2);
+  Float_t sigma_h = (pp+X).E() - (pp+X).Z();
+  Float_t pT2_e = ep.Pt() * ep.Pt();
+  Float_t sigma_e = ep.E() - ep.Z();
+  Float_t sigma_tot = sigma_e + sigma_h;
+
+  // Kinematic variables
+  Float_t y_sigma = sigma_h/sigma_tot;
+  Float_t Q2_sigma = pT2_e / (1-y_sigma);
+  
+  return Q2_sigma;
+}
+// x
+template <typename V>
+Double_t calcX_Sigma(const V& e, const V& p, const V& ep, const V& pp, const V& X){
+  // Intermediate variables
+  Float_t pT2_h = TMath::Power((pp+X).X(),2) + TMath::Power((pp+X).Y(),2);
+  Float_t sigma_h = (pp+X).E() - (pp+X).Z();
+  Float_t pT2_e = ep.Pt() * ep.Pt();
+  Float_t sigma_e = ep.E() - ep.Z();
+  Float_t sigma_tot = sigma_e + sigma_h;
+
+  // Kinematic variables
+  Float_t y_sigma = sigma_h/sigma_tot;
+  Float_t Q2_sigma = pT2_e / (1-y_sigma);
+  Float_t x_sigma = Q2_sigma / (4*e.E()*p.E()*y_sigma);
+  
+  return x_sigma;
+}
+// y
+template <typename V>
+Double_t calcY_Sigma(const V& ep, const V& pp, const V& X){
+  // Intermediate variables
+  Float_t pT2_h = TMath::Power((pp+X).X(),2) + TMath::Power((pp+X).Y(),2);
+  Float_t sigma_h = (pp+X).E() - (pp+X).Z();
+  Float_t sigma_e = ep.E() - ep.Z();
+  Float_t sigma_tot = sigma_e + sigma_h;
+
+  // Kinematic variables
+  Float_t y_sigma = sigma_h/sigma_tot;
+
+  return y_sigma;
+}
+// Calculate all 3 kinematic variables (Q2, x, y) simultaneously and pass them to holding variables 
+template <typename V>
+void calcKin_Sigma(const V& e, const V& p, const V& ep, const V& pp, const V& X, Float_t &Q2, Float_t &x, Float_t &y){
+  // Reset kinematic variables
+  Q2 = 0;
+  x = 0;
+  y = 0;
+  
+  // Intermediate variables
+  Float_t pT2_h = TMath::Power((pp+X).X(),2) + TMath::Power((pp+X).Y(),2);
+  Float_t sigma_h = (pp+X).E() - (pp+X).Z();
+  Float_t pT2_e = ep.Pt() * ep.Pt();
+  Float_t sigma_e = ep.E() - ep.Z();
+  Float_t sigma_tot = sigma_e + sigma_h;
+
+  // Kinematic variables
+  Float_t y_sigma = sigma_h/sigma_tot;
+  Float_t Q2_sigma = pT2_e / (1-y_sigma);
+  Float_t x_sigma = Q2_sigma / (4*e.E()*p.E()*y_sigma);
+  
+  // Export kinematic variables
+  Q2 = Q2_sigma;
+  x = x_sigma;
+  y = y_sigma;
+}
+
+// DIS case ep -> e'X
+// Q2
+template <typename V>
+Double_t calcQ2_Sigma(const V& ep, const V& HFS){
+  // Intermediate variables
+  Float_t pT2_h = TMath::Power(HFS.X(),2) + TMath::Power(HFS.Y(),2);
+  Float_t sigma_h = HFS.E() - HFS.Z();
+  Float_t pT2_e = ep.Pt() * ep.Pt();
+  Float_t sigma_e = ep.E() - ep.Z();
+  Float_t sigma_tot = sigma_e + sigma_h;
+
+  // Kinematic variables
+  Float_t y_sigma = sigma_h/sigma_tot;
+  Float_t Q2_sigma = pT2_e / (1-y_sigma);
+  
+  return Q2_sigma;
+}
+// x
+template <typename V>
+Double_t calcX_Sigma(const V& e, const V& p, const V& ep, const V& HFS){
+  // Intermediate variables
+  Float_t pT2_h = TMath::Power(HFS.X(),2) + TMath::Power(HFS.Y(),2);
+  Float_t sigma_h = HFS.E() - HFS.Z();
+  Float_t pT2_e = ep.Pt() * ep.Pt();
+  Float_t sigma_e = ep.E() - ep.Z();
+  Float_t sigma_tot = sigma_e + sigma_h;
+
+  // Kinematic variables
+  Float_t y_sigma = sigma_h/sigma_tot;
+  Float_t Q2_sigma = pT2_e / (1-y_sigma);
+  Float_t x_sigma = Q2_sigma / (4*e.E()*p.E()*y_sigma);
+  
+  return x_sigma;
+}
+// y
+template <typename V>
+Double_t calcY_Sigma(const V& ep, const V& HFS){
+  // Intermediate variables
+  Float_t pT2_h = TMath::Power(HFS.X(),2) + TMath::Power(HFS.Y(),2);
+  Float_t sigma_h = HFS.E() - HFS.Z();
+  Float_t sigma_e = ep.E() - ep.Z();
+  Float_t sigma_tot = sigma_e + sigma_h;
+
+  // Kinematic variables
+  Float_t y_sigma = sigma_h/sigma_tot;
+
+  return y_sigma;
+}
+// Calculate all 3 kinematic variables (Q2, x, y) simultaneously and pass them to holding variables 
+template <typename V>
+void calcKin_Sigma(const V& e, const V& p, const V& ep, const V& HFS, Float_t &Q2, Float_t &x, Float_t &y){
+  // Reset kinematic variables
+  Q2 = 0;
+  x = 0;
+  y = 0;
+  
+  // Intermediate variables
+  Float_t pT2_h = TMath::Power(HFS.X(),2) + TMath::Power(HFS.Y(),2);
+  Float_t sigma_h = HFS.E() - HFS.Z();
+  Float_t pT2_e = ep.Pt() * ep.Pt();
+  Float_t sigma_e = ep.E() - ep.Z();
+  Float_t sigma_tot = sigma_e + sigma_h;
+
+  // Kinematic variables
+  Float_t y_sigma = sigma_h/sigma_tot;
+  Float_t Q2_sigma = pT2_e / (1-y_sigma);
+  Float_t x_sigma = Q2_sigma / (4*e.E()*p.E()*y_sigma);
+  
+  // Export kinematic variables
+  Q2 = Q2_sigma;
+  x = x_sigma;
+  y = y_sigma;
+}
+
+// Calculate inclusive kinematics (Q2, x, y) with the e-Sigma method
+// SIDIS case ep -> e'p'X
+// Q2
+template <typename V>
+Double_t calcQ2_ESigma(const V& e, const V& ep){
+  // Intermediate variables
+  Float_t pT2_e = ep.Pt() * ep.Pt();
+  Float_t sigma_e = ep.E() - ep.Z();
+
+  // Electron-based kinematics
+  Float_t y_e = 1 - sigma_e / (2*e.E());
+  Float_t Q2_e = pT2_e / (1-y_e);
+
+  return Q2_e;
+}
+// x
+template <typename V>
+Double_t calcX_ESigma(const V& e, const V& p, const V& ep, const V& pp, const V& X){
+  // Intermediate variables
+  Float_t sigma_h = (pp+X).E() - (pp+X).Z();
+  Float_t pT2_e = ep.Pt() * ep.Pt();
+  Float_t sigma_e = ep.E() - ep.Z();
+  Float_t sigma_tot = sigma_e + sigma_h;
+
+  // Hadron-based kinematics
+  Float_t y_sigma = sigma_h/sigma_tot;
+  Float_t Q2_sigma = pT2_e / (1-y_sigma);
+  Float_t x_sigma = Q2_sigma / (4*e.E()*p.E()*y_sigma);
+
+  return x_sigma;
+}
+// y
+template <typename V>
+Double_t calcY_ESigma(const V& e, const V& p, const V& ep, const V& pp, const V& X){
+  // Intermediate variables
+  Float_t sigma_h = (pp+X).E() - (pp+X).Z();
+  Float_t pT2_e = ep.Pt() * ep.Pt();
+  Float_t sigma_e = ep.E() - ep.Z();
+  Float_t sigma_tot = sigma_e + sigma_h;
+
+  // Electron-based kinematics
+  Float_t y_e = 1 - sigma_e / (2*e.E());
+  Float_t Q2_e = pT2_e / (1-y_e);
+
+  // Hadron-based kinematics
+  Float_t y_sigma = sigma_h/sigma_tot;
+  Float_t Q2_sigma = pT2_e / (1-y_sigma);
+  Float_t x_sigma = Q2_sigma / (4*e.E()*p.E()*y_sigma);
+
+  // Mixed kinematics
+  Float_t y_esigma = Q2_e / (4*e.E()*p.E()*x_sigma);
+
+  return y_esigma;
+}
+// Calculate all 3 kinematic variables (Q2, x, y) simultaneously and pass them to holding variables 
+template <typename V>
+void calcKin_ESigma(const V& e, const V& p, const V& ep, const V& pp, const V& X, Float_t &Q2, Float_t &x, Float_t &y){
+  // Reset kinematic variables
+  Q2 = 0;
+  x = 0;
+  y = 0;
+  
+  // Intermediate variables
+  Float_t sigma_h = (pp+X).E() - (pp+X).Z();
+  Float_t pT2_e = ep.Pt() * ep.Pt();
+  Float_t sigma_e = ep.E() - ep.Z();
+  Float_t sigma_tot = sigma_e + sigma_h;
+
+  // Electron-based kinematics
+  Float_t y_e = 1 - sigma_e / (2*e.E());
+  Float_t Q2_e = pT2_e / (1-y_e);
+
+  // Hadron-based kinematics
+  Float_t y_sigma = sigma_h/sigma_tot;
+  Float_t Q2_sigma = pT2_e / (1-y_sigma);
+  Float_t x_sigma = Q2_sigma / (4*e.E()*p.E()*y_sigma);
+
+  // Mixed kinematics
+  Float_t y_esigma = Q2_e / (4*e.E()*p.E()*x_sigma);
+
+  // Export kinematics
+  Q2 = Q2_e;
+  x = x_sigma;
+  y = y_esigma;
+}
+
+// DIS case ep -> e'X
+// NO NEED TO REDEFINE Q2 - ONLY DEPENDS ON BEAM AND SCATTERED ELECTRON
+// x
+template <typename V>
+Double_t calcX_ESigma(const V& e, const V& p, const V& ep, const V& HFS){
+  // Intermediate variables
+  Float_t sigma_h = HFS.E() - HFS.Z();
+  Float_t pT2_e = ep.Pt() * ep.Pt();
+  Float_t sigma_e = ep.E() - ep.Z();
+  Float_t sigma_tot = sigma_e + sigma_h;
+
+  // Hadron-based kinematics
+  Float_t y_sigma = sigma_h/sigma_tot;
+  Float_t Q2_sigma = pT2_e / (1-y_sigma);
+  Float_t x_sigma = Q2_sigma / (4*e.E()*p.E()*y_sigma);
+
+  return x_sigma;
+}
+// y
+template <typename V>
+Double_t calcY_ESigma(const V& e, const V& p, const V& ep, const V& HFS){
+  // Intermediate variables
+  Float_t sigma_h = HFS.E() - HFS.Z();
+  Float_t pT2_e = ep.Pt() * ep.Pt();
+  Float_t sigma_e = ep.E() - ep.Z();
+  Float_t sigma_tot = sigma_e + sigma_h;
+
+  // Electron-based kinematics
+  Float_t y_e = 1 - sigma_e / (2*e.E());
+  Float_t Q2_e = pT2_e / (1-y_e);
+
+  // Hadron-based kinematics
+  Float_t y_sigma = sigma_h/sigma_tot;
+  Float_t Q2_sigma = pT2_e / (1-y_sigma);
+  Float_t x_sigma = Q2_sigma / (4*e.E()*p.E()*y_sigma);
+
+  // Mixed kinematics
+  Float_t y_esigma = Q2_e / (4*e.E()*p.E()*x_sigma);
+
+  return y_esigma;
+}
+// Calculate all 3 kinematic variables (Q2, x, y) simultaneously and pass them to holding variables 
+template <typename V>
+void calcKin_ESigma(const V& e, const V& p, const V& ep, const V& HFS, Float_t &Q2, Float_t &x, Float_t &y){
+   // Reset kinematic variables
+  Q2 = 0;
+  x = 0;
+  y = 0;
+  
+  // Intermediate variables
+  Float_t sigma_h = HFS.E() - HFS.Z();
+  Float_t pT2_e = ep.Pt() * ep.Pt();
+  Float_t sigma_e = ep.E() - ep.Z();
+  Float_t sigma_tot = sigma_e + sigma_h;
+
+  // Electron-based kinematics
+  Float_t y_e = 1 - sigma_e / (2*e.E());
+  Float_t Q2_e = pT2_e / (1-y_e);
+
+  // Hadron-based kinematics
+  Float_t y_sigma = sigma_h/sigma_tot;
+  Float_t Q2_sigma = pT2_e / (1-y_sigma);
+  Float_t x_sigma = Q2_sigma / (4*e.E()*p.E()*y_sigma);
+
+  // Mixed kinematics
+  Float_t y_esigma = Q2_e / (4*e.E()*p.E()*x_sigma);
+
+  // Export kinematics
+  Q2 = Q2_e;
+  x = x_sigma;
+  y = y_esigma;
+}


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR introduces 2 new header files, both containing useful functions which ePIC users might wish to use in their analysis. The calculations added (for Q2, x, y, Mandelstam t, and missing kinematic quantities - mass, momentum and energy) will be common to many analyses; putting these into a small number of header files will reduce the need for every new script to redefine how such quantities are calculated.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [X] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [X] Documentation has been added / updated
- [X] Changes have been communicated to collaborators

[https://indico.bnl.gov/event/26528/contributions/105021/attachments/60860/104545/PWGEDTUpdate-250324.pdf](https://indico.bnl.gov/event/26528/contributions/105021/attachments/60860/104545/PWGEDTUpdate-250324.pdf)

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No breaking changes. Users who wish to use the files added will need to `#include` them in their analysis scripts.

### Does this PR change default behavior?
No.