### PR TITLE
Modify reconstructed charged particle associations

### DIFF
--- a/JetsAndHF/jetReaderExamples/jetReader_TTreeReader.C
+++ b/JetsAndHF/jetReaderExamples/jetReader_TTreeReader.C
@@ -37,8 +37,16 @@ void jetReader_TTreeReader(TString infile="root://dtn-eic.jlab.org//volatile/eic
   TTreeReaderArray<int> recoPartPDG = {tree_reader, "ReconstructedChargedParticles.PDG"};
   TTreeReaderArray<float> recoPartNRG = {tree_reader, "ReconstructedChargedParticles.energy"};
 
-  TTreeReaderArray<unsigned int> recoPartAssocRec = {tree_reader, "ReconstructedChargedParticleAssociations.recID"}; // Reco <-> MCParticle
-  TTreeReaderArray<unsigned int> recoPartAssocSim = {tree_reader, "ReconstructedChargedParticleAssociations.simID"};
+  // Uncomment the following two lines if using older than eic-shell --version 25.12.0-stable
+  // Refer https://chat.epic-eic.org/main/pl/n9mbqtf4fiyptjz9q13f7m8xne
+
+  //TTreeReaderArray<unsigned int> recoPartAssocRec = {tree_reader, "ReconstructedChargedParticleAssociations.recID"}; // Reco <-> MCParticle
+  //TTreeReaderArray<unsigned int> recoPartAssocSim = {tree_reader, "ReconstructedChargedParticleAssociations.simID"};
+
+  // updated code after eic-shell --version 25.12.0-stable
+  TTreeReaderArray<int> recoPartAssocRec = {tree_reader, "_ReconstructedChargedParticleAssociations_rec.index"}; // Reco <-> MCParticle
+  TTreeReaderArray<int> recoPartAssocSim = {tree_reader, "_ReconstructedChargedParticleAssociations_sim.index"};
+
   TTreeReaderArray<float> recoPartAssocWeight = {tree_reader, "ReconstructedChargedParticleAssociations.weight"};
 
   // Generated Jets

--- a/JetsAndHF/jetReaderExamples/jetReader_TTreeReader.C
+++ b/JetsAndHF/jetReaderExamples/jetReader_TTreeReader.C
@@ -37,7 +37,7 @@ void jetReader_TTreeReader(TString infile="root://dtn-eic.jlab.org//volatile/eic
   TTreeReaderArray<int> recoPartPDG = {tree_reader, "ReconstructedChargedParticles.PDG"};
   TTreeReaderArray<float> recoPartNRG = {tree_reader, "ReconstructedChargedParticles.energy"};
 
-  // Uncomment the following two lines if using older than eic-shell --version 25.12.0-stable
+  // Uncomment the following two lines if using an eic-shell version older than 25.12.0-stable
   // Refer https://chat.epic-eic.org/main/pl/n9mbqtf4fiyptjz9q13f7m8xne
 
   //TTreeReaderArray<unsigned int> recoPartAssocRec = {tree_reader, "ReconstructedChargedParticleAssociations.recID"}; // Reco <-> MCParticle


### PR DESCRIPTION
Updated associations for reconstructed charged particles to reflect changes after eic-shell version update.

### Briefly, what does this PR introduce?
After the recent update of eic-shell version 25.12.0-stable, the methods for calling particle associations changed. This has been discussed [here](https://chat.epic-eic.org/main/pl/n9mbqtf4fiyptjz9q13f7m8xne). So changed the associations to be compatible wih updated eic-shell.

### What kind of change does this PR introduce?
- [x] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
Update your code to reflect methods for returning particle associations.

### Does this PR change default behavior?
