### PR TITLE
Update versions.py: git fetch, 4 new packages, --output-dir, robust error handling

### DIFF
--- a/Infrastructure/Acts_versions/plot.py
+++ b/Infrastructure/Acts_versions/plot.py
@@ -1,78 +1,178 @@
-from datetime import datetime, timedelta
+#!/usr/bin/env python3
+"""
+Visualise the release timeline of a software component and its integration
+into the ePIC stack container.
 
+Reads the three output files produced by versions.py:
+  - tags: all upstream release tags with dates
+  - eic_container_tags: filtered eic/containers stable tags with dates
+  - result: upstream version tag + date for each matched container tag
+
+Usage:
+  python plot.py [--component NAME] [--skip N] [--input-dir DIR] [--output FILE]
+"""
+
+import argparse
+import os
+from datetime import datetime
+
+import matplotlib as mpl
+import matplotlib.pyplot as plt
 import numpy as np
 
-import matplotlib.pyplot as plt
-import matplotlib as mpl
 
-COMPONENT = "DD4hep"
-
-@np.vectorize
-def to_datetime(date):
-    return datetime.strptime(date, '%b %d %Y %H:%M:%S') 
-
-with open("tags") as fp:
-    tags = np.array([l.strip().replace("refs/tags/v", "").split("|") for l in fp.readlines()])
-tags_dates = to_datetime(tags[:,1])
-order = np.argsort(tags_dates)
-skip = {
+# Default number of early upstream tags to skip per component (to focus on
+# the era relevant to ePIC/EIC containers).
+DEFAULT_SKIP = {
     "Acts": 101,
     "DD4hep": 61,
-}[COMPONENT]
-tags = tags[order][skip:]
-tags_dates = tags_dates[order][skip:]
+}
 
-with open("eic_container_tags") as fp:
-    eic_container_tags = np.array([l.strip().split("|") for l in fp.readlines()])
-eic_container_tags_dates = to_datetime(eic_container_tags[:,1])
-order = np.argsort(eic_container_tags_dates)
-eic_container_tags = eic_container_tags[order]
-eic_container_tags_dates = eic_container_tags_dates[order]
+# Annotation offset parameters per component.  Each callable receives the
+# (integer) tag index and returns an (x, y) offset in points.
+DEFAULT_ANNOTATION_PARAMS: dict[str, dict] = {
+    "Acts": {
+        "divisor": 60.0,
+        "label_xy": lambda ix: ((-200 + ix * 1.5), (ix * 0.8 - 50)),
+        "container_xy": lambda ix: ((-100 + ix), (-80 + ix * 0.5)),
+    },
+    "DD4hep": {
+        "divisor": 8.0,
+        "label_xy": lambda ix: ((-100 + 2 * ix), (ix * 2.4 - 10)),
+        "container_xy": lambda ix: ((-10 + 2 * ix), (-80 + ix)),
+    },
+}
 
-with open("result") as fp:
-    result = np.array([l.strip().split("|") for l in fp.readlines()])
-result_dates = to_datetime(result[:,1])
-order = np.argsort(result_dates)
-result = result[order]
-result_dates = result_dates[order]
 
-assert len(eic_container_tags) == len(result)
+@np.vectorize
+def to_datetime(date: str) -> datetime:
+    return datetime.strptime(date, "%b %d %Y %H:%M:%S")
 
-result_ixs, tags_ixs = np.nonzero(result[:,0][:,np.newaxis] == tags[:,0][np.newaxis,:])
-print(result_ixs)
-print(tags_ixs)
 
 def annotate(ax, label, x, y, xytext):
-    ax.annotate(label, xy=(x,y),
-                xytext=xytext, textcoords='offset points',
-                fontsize=5,
-                arrowprops={'arrowstyle': '-|>', 'color': 'black', 'linewidth': 1.})
+    ax.annotate(
+        label,
+        xy=(x, y),
+        xytext=xytext,
+        textcoords="offset points",
+        fontsize=5,
+        arrowprops={"arrowstyle": "-|>", "color": "black", "linewidth": 1.0},
+    )
 
-#plt.xkcd()
-fig, ax = plt.subplots(figsize=(6.4, 3), layout='constrained')
 
-x = np.arange(len(tags))
-ax.plot(tags_dates, x, label=f"{COMPONENT} releases")
-ax.plot(eic_container_tags_dates[result_ixs], tags_ixs, label="ePIC stack releases")
+def load_tag_file(path: str) -> np.ndarray:
+    """Read a tag file (tag|date lines) and return a 2-column string array."""
+    with open(path) as fp:
+        rows = [l.strip().split("|") for l in fp if l.strip()]
+    return np.array(rows)
 
-ax.yaxis.set_major_locator(mpl.ticker.MaxNLocator(integer=True))
-ax.xaxis.set_major_locator(mpl.dates.YearLocator())
-ax.xaxis.set_major_formatter(mpl.dates.DateFormatter('%Y'))
-container_bump_ix = np.nonzero(result[1:,0] != result[:-1,0])[0] + 1
-assert np.allclose(result_ixs, range(len(result_ixs)))
-for cix, ix in zip(container_bump_ix, tags_ixs[container_bump_ix]):
-    f = {
-        "Acts": np.tanh(ix / 60.),
-        "DD4hep": np.tanh(ix / 8.),
-    }[COMPONENT]
-    if COMPONENT == "Acts":
-        annotate(plt.gca(), tags[ix,0], tags_dates[ix], ix, ((-200 + ix * 1.5) * f, (ix * 0.8 - 50) * f))
-        annotate(plt.gca(), eic_container_tags[cix,0], eic_container_tags_dates[cix], ix, ((-100 + ix) * f, (-80 + ix * 0.5) * f))
-    elif COMPONENT == "DD4hep":
-        annotate(plt.gca(), tags[ix,0], tags_dates[ix], ix, ((-100 + 2 * ix) * f, (ix * 2.4 - 10) * f))
-        annotate(plt.gca(), eic_container_tags[cix,0], eic_container_tags_dates[cix], ix, ((-10 + 2 * ix) * f, (-80 + ix) * f))
-plt.ylabel(f"{COMPONENT} version index", loc="top")
-plt.legend()
-ax.spines[['right', 'top']].set_visible(False)
-plt.savefig("fig.png", dpi=300)
-plt.show()
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--component", "-c",
+        default="DD4hep",
+        help="Component display name for axis labels (default: DD4hep). "
+             f"Auto-skip configured for: {', '.join(sorted(DEFAULT_SKIP))}.",
+    )
+    parser.add_argument(
+        "--skip", "-s",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Number of early upstream tags to skip before plotting "
+             "(default: auto per --component, 0 for unknown components).",
+    )
+    parser.add_argument(
+        "--input-dir", "-i",
+        default=".",
+        metavar="DIR",
+        help="Directory containing tags, eic_container_tags, result files "
+             "(default: current directory).",
+    )
+    parser.add_argument(
+        "--output", "-O",
+        default="fig.png",
+        metavar="FILE",
+        help="Output figure path (default: fig.png).",
+    )
+    args = parser.parse_args()
+
+    component = args.component
+    skip = args.skip if args.skip is not None else DEFAULT_SKIP.get(component, 0)
+
+    def inp(filename):
+        return os.path.join(args.input_dir, filename)
+
+    tags = load_tag_file(inp("tags"))
+    tags_dates = to_datetime(tags[:, 1])
+    order = np.argsort(tags_dates)
+    tags = tags[order][skip:]
+    tags_dates = tags_dates[order][skip:]
+
+    eic_container_tags = load_tag_file(inp("eic_container_tags"))
+    eic_container_tags_dates = to_datetime(eic_container_tags[:, 1])
+    order = np.argsort(eic_container_tags_dates)
+    eic_container_tags = eic_container_tags[order]
+    eic_container_tags_dates = eic_container_tags_dates[order]
+
+    result = load_tag_file(inp("result"))
+    result_dates = to_datetime(result[:, 1])
+    order = np.argsort(result_dates)
+    result = result[order]
+    result_dates = result_dates[order]
+
+    if len(eic_container_tags) != len(result):
+        raise ValueError(
+            f"Length mismatch: {len(eic_container_tags)} entries in 'eic_container_tags' "
+            f"but {len(result)} entries in 'result'. "
+            "Re-run versions.py to regenerate consistent data files."
+        )
+
+    result_ixs, tags_ixs = np.nonzero(
+        result[:, 0][:, np.newaxis] == tags[:, 0][np.newaxis, :]
+    )
+    print(result_ixs)
+    print(tags_ixs)
+
+    fig, ax = plt.subplots(figsize=(6.4, 3), layout="constrained")
+    ax.plot(tags_dates, np.arange(len(tags)), label=f"{component} releases")
+    ax.plot(
+        eic_container_tags_dates[result_ixs],
+        tags_ixs,
+        label="ePIC stack releases",
+    )
+
+    ax.yaxis.set_major_locator(mpl.ticker.MaxNLocator(integer=True))
+    ax.xaxis.set_major_locator(mpl.dates.YearLocator())
+    ax.xaxis.set_major_formatter(mpl.dates.DateFormatter("%Y"))
+
+    container_bump_ix = np.nonzero(result[1:, 0] != result[:-1, 0])[0] + 1
+    assert np.allclose(result_ixs, range(len(result_ixs)))
+
+    ann_params = DEFAULT_ANNOTATION_PARAMS.get(component)
+    for cix, ix in zip(container_bump_ix, tags_ixs[container_bump_ix]):
+        if ann_params is None:
+            continue
+        f = np.tanh(ix / ann_params["divisor"])
+        lxy = ann_params["label_xy"](ix)
+        cxy = ann_params["container_xy"](ix)
+        annotate(ax, tags[ix, 0], tags_dates[ix], ix,
+                 (lxy[0] * f, lxy[1] * f))
+        annotate(ax, eic_container_tags[cix, 0], eic_container_tags_dates[cix], ix,
+                 (cxy[0] * f, cxy[1] * f))
+
+    ax.set_ylabel(f"{component} version index", loc="top")
+    ax.legend()
+    ax.spines[["right", "top"]].set_visible(False)
+
+    plt.savefig(args.output, dpi=300)
+    print(f"Figure saved to {args.output}")
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/Infrastructure/Acts_versions/versions.py
+++ b/Infrastructure/Acts_versions/versions.py
@@ -7,15 +7,21 @@ the eic/containers repo at each tag and reads the package version directly from
 either spack-environment/packages.yaml (newer format) or
 spack-environment/dev/spack.yaml (older format) or spack.yaml (earliest tags).
 
-Produces the same output files as versions.sh / versions_dd4hep.sh:
+Unlike versions.sh / versions_dd4hep.sh (which require singularity and skip
+early container tags), this script works purely from git history and covers
+all stable tags including v23.* and v24.02.*.
+
+Output files:
   - tags: all upstream release tags with dates
-  - eic_container_tags: filtered eic/containers tags with dates
-  - result: upstream version tag + date for each container tag
+  - eic_container_tags: filtered eic/containers stable tags with dates
+  - result: upstream version tag + date for each matched container tag
 
 Usage:
-  python versions.py [package]
+  python versions.py [package] [--output-dir DIR] [--no-fetch]
+  python versions.py --list-packages
 
-  package: acts (default), dd4hep, or any spack package name
+  package: acts (default), dd4hep, eicrecon, podio, edm4hep, geant4,
+           or any other preconfigured package name.
 """
 
 import argparse
@@ -37,17 +43,29 @@ import yaml
 # ---------------------------------------------------------------------------
 
 def _identity_version_to_tag(version):
-    """v{version} — used by acts and most projects."""
+    """v{version} — used by acts, eicrecon, and most semver projects."""
     return f"v{version}"
 
 
-def _dd4hep_version_to_tag(version):
+def _hep_version_to_tag(version):
     """
-    DD4hep spack version '1.25.1' -> git tag 'v01-25-01'.
+    HEP-style spack version '1.25.1' -> git tag 'v01-25-01'.
     Each dot-separated component is zero-padded to 2 digits, joined by '-'.
+    Used by DD4hep, podio, and EDM4hep.
     """
     parts = version.split(".")
     return "v" + "-".join(p.zfill(2) for p in parts)
+
+
+def _geant4_version_to_tag(version):
+    """
+    Geant4 spack version '11.3.2' or '11.3.2.east' -> git tag 'v11.3.2'.
+    Strips EIC-specific patch suffixes (e.g., '.east') beyond the 3rd component.
+    Note: versions ending in '.east' are EIC-patched builds with no exact upstream tag;
+    the tag for the unpatched base release is returned instead.
+    """
+    parts = version.split(".")
+    return "v" + ".".join(parts[:3])
 
 
 PACKAGES = {
@@ -57,9 +75,29 @@ PACKAGES = {
         "version_to_tag": _identity_version_to_tag,
     },
     "dd4hep": {
-        "repo_url": "https://github.com/AIDASoft/DD4hep.git",
+        "repo_url": "https://github.com/AIDASoft/DD4hep",
         "repo_dir": "DD4hep",
-        "version_to_tag": _dd4hep_version_to_tag,
+        "version_to_tag": _hep_version_to_tag,
+    },
+    "eicrecon": {
+        "repo_url": "https://github.com/eic/EICrecon",
+        "repo_dir": "EICrecon",
+        "version_to_tag": _identity_version_to_tag,
+    },
+    "podio": {
+        "repo_url": "https://github.com/AIDASoft/podio",
+        "repo_dir": "podio",
+        "version_to_tag": _hep_version_to_tag,
+    },
+    "edm4hep": {
+        "repo_url": "https://github.com/key4hep/EDM4hep",
+        "repo_dir": "EDM4hep",
+        "version_to_tag": _hep_version_to_tag,
+    },
+    "geant4": {
+        "repo_url": "https://github.com/Geant4/geant4",
+        "repo_dir": "geant4",
+        "version_to_tag": _geant4_version_to_tag,
     },
 }
 
@@ -69,42 +107,53 @@ PACKAGES = {
 # ---------------------------------------------------------------------------
 
 def run(cmd, **kwargs):
-    """Run a shell command and return stdout."""
-    result = subprocess.run(cmd, capture_output=True, text=True, **kwargs)
-    if result.returncode != 0:
-        print(f"Command failed: {' '.join(cmd)}", file=sys.stderr)
-        print(result.stderr, file=sys.stderr)
-    return result.stdout
+    """Run a shell command and return the CompletedProcess result."""
+    return subprocess.run(cmd, capture_output=True, text=True, **kwargs)
 
 
-def clone_if_missing(url, path):
-    """Clone a git repository if the directory doesn't already exist."""
+def clone_or_fetch(url, path, fetch=True):
+    """
+    Clone a git repository if the directory doesn't exist; otherwise fetch new tags.
+    Exits with an error if the initial clone fails.
+    """
     if not os.path.isdir(path):
-        print(f"Cloning {url}...")
-        run(["git", "clone", url, path])
-    else:
-        print(f"Using existing {path}")
+        print(f"Cloning {url} -> {path} ...")
+        result = run(["git", "clone", url, path])
+        if result.returncode != 0:
+            print(f"ERROR: git clone failed for {url}:", file=sys.stderr)
+            print(result.stderr, file=sys.stderr)
+            sys.exit(1)
+    elif fetch:
+        print(f"Fetching new tags in {path} ...")
+        result = run(["git", "-C", path, "fetch", "--tags", "--quiet"])
+        if result.returncode != 0:
+            print(
+                f"WARNING: git fetch failed for {path}: {result.stderr.strip()}",
+                file=sys.stderr,
+            )
 
 
 def get_tags_with_dates(repo_path):
     """
     Get all tags with their creator dates from a git repo.
     Returns list of "tag|date" strings.
+    Exits with an error if the git command fails.
     """
-    output = run(
+    result = run(
         ["git", "-C", repo_path, "for-each-ref",
          "--format=%(refname:short)|%(creatordate:format:%b %d %Y %H:%M:%S)",
-         "refs/tags/*"]
+         "refs/tags/*"],
     )
-    return [line for line in output.strip().splitlines() if line]
+    if result.returncode != 0:
+        print(f"ERROR: failed to list tags in {repo_path}:", file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        sys.exit(1)
+    return [line for line in result.stdout.strip().splitlines() if line]
 
 
 def git_show(repo_path, ref, filepath):
-    """Show file content at a given git ref. Returns None if file doesn't exist."""
-    result = subprocess.run(
-        ["git", "-C", repo_path, "show", f"{ref}:{filepath}"],
-        capture_output=True, text=True,
-    )
+    """Show file content at a given git ref. Returns None if file doesn't exist at that ref."""
+    result = run(["git", "-C", repo_path, "show", f"{ref}:{filepath}"])
     if result.returncode != 0:
         return None
     return result.stdout
@@ -116,18 +165,25 @@ def git_show(repo_path, ref, filepath):
 
 def extract_version_from_spack_yaml(content, spack_name):
     """
-    Extract version from spack.yaml / spack-environment/dev/spack.yaml format:
-      spack:
-        specs:
-          - <spack_name>@<version> ...
+    Extract version from spack.yaml / spack-environment/dev/spack.yaml format::
+
+        spack:
+          specs:
+            - <spack_name>@<version> ...
+
+    Uses an exact package-name match to avoid e.g. ``acts-dd4hep`` matching ``dd4hep``.
     """
-    data = yaml.safe_load(content)
+    try:
+        data = yaml.safe_load(content)
+    except yaml.YAMLError:
+        return None
     if not data:
         return None
     specs = data.get("spack", {}).get("specs", [])
-    # Match exact package name followed by @version (avoid e.g. acts-dd4hep matching dd4hep)
     pattern = re.compile(r"^" + re.escape(spack_name) + r"@([^\s]+)")
     for spec in specs:
+        if not isinstance(spec, str):
+            continue
         m = pattern.match(spec)
         if m:
             return m.group(1)
@@ -136,26 +192,36 @@ def extract_version_from_spack_yaml(content, spack_name):
 
 def extract_version_from_packages_yaml(content, spack_name):
     """
-    Extract version from packages.yaml format:
-      packages:
-        <spack_name>:
-          require:
-          - '@<version>'
-          - ...
+    Extract version from packages.yaml format::
+
+        packages:
+          <spack_name>:
+            require:
+            - '@<version>'
+
+    Handles both plain string entries and ``{spec: ..., when: ...}`` dict entries.
+    After yaml.safe_load(), YAML quoting is already stripped, so the entry is
+    a plain Python string such as ``@44.4.0``.
     """
-    data = yaml.safe_load(content)
+    try:
+        data = yaml.safe_load(content)
+    except yaml.YAMLError:
+        return None
     if not data:
         return None
     pkg = data.get("packages", {}).get(spack_name, {})
+    if not pkg:
+        return None
     require = pkg.get("require", [])
+    version_re = re.compile(r"@([0-9][^\s]*)")
     for entry in require:
         if isinstance(entry, str):
-            m = re.match(r"'?@([0-9][^']*)'?", entry)
+            m = version_re.match(entry)
             if m:
                 return m.group(1)
         elif isinstance(entry, dict):
             spec = entry.get("spec", "")
-            m = re.match(r"'?@([0-9][^']*)'?", spec)
+            m = version_re.match(spec)
             if m:
                 return m.group(1)
     return None
@@ -164,7 +230,13 @@ def extract_version_from_packages_yaml(content, spack_name):
 def get_package_version(containers_path, tag, spack_name):
     """
     Try to extract a spack package version from a container tag.
-    Searches multiple file locations in order.
+
+    Searches the following paths in order (newest to oldest format):
+
+    1. ``spack-environment/packages.yaml``  — v24.03+
+    2. ``spack-environment/dev/spack.yaml`` — v23.05–v24.02
+    3. ``spack.yaml``                       — earliest tags (~v23.03)
+    4. ``spack.yml``                        — fallback spelling
     """
     # Try packages.yaml first (newer format, ~v24.03+)
     content = git_show(containers_path, tag, "spack-environment/packages.yaml")
@@ -180,7 +252,7 @@ def get_package_version(containers_path, tag, spack_name):
         if version:
             return version
 
-    # Try spack.yaml or spack.yml at root (earliest tags, ~v23.03)
+    # Try root-level spack.yaml / spack.yml (earliest tags, ~v23.03)
     for filename in ("spack.yaml", "spack.yml"):
         content = git_show(containers_path, tag, filename)
         if content:
@@ -197,94 +269,125 @@ def get_package_version(containers_path, tag, spack_name):
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Extract package versions from eic/containers tags."
+        description="Extract package versions from eic/containers tags.",
     )
     parser.add_argument(
         "package",
         nargs="?",
         default="acts",
-        help="Spack package name (default: acts). "
-             f"Preconfigured: {', '.join(sorted(PACKAGES))}. "
-             "Other names will be looked up with v{{version}} tag convention.",
+        help=(
+            "Spack package name to track (default: acts). "
+            f"Preconfigured: {', '.join(sorted(PACKAGES))}. "
+            "Use --list-packages for details."
+        ),
+    )
+    parser.add_argument(
+        "--output-dir", "-o",
+        default=".",
+        metavar="DIR",
+        help="Directory for output files (tags, eic_container_tags, result). Default: '.'",
+    )
+    parser.add_argument(
+        "--no-fetch",
+        action="store_true",
+        help="Skip 'git fetch' when repos already exist (use cached data).",
+    )
+    parser.add_argument(
+        "--list-packages",
+        action="store_true",
+        help="List all preconfigured packages and exit.",
     )
     args = parser.parse_args()
 
-    spack_name = args.package
-    pkg_config = PACKAGES.get(spack_name, {
-        "repo_url": None,
-        "repo_dir": None,
-        "version_to_tag": _identity_version_to_tag,
-    })
+    if args.list_packages:
+        print("Preconfigured packages:")
+        for name, cfg in sorted(PACKAGES.items()):
+            print(f"  {name:12s}  {cfg['repo_url']}")
+        return
 
+    spack_name = args.package
+    if spack_name not in PACKAGES:
+        print(f"ERROR: Unknown package '{spack_name}'.", file=sys.stderr)
+        print(f"  Known packages: {', '.join(sorted(PACKAGES))}", file=sys.stderr)
+        print("  Add an entry to PACKAGES in this script to support additional packages.", file=sys.stderr)
+        sys.exit(1)
+
+    pkg_config = PACKAGES[spack_name]
     repo_url = pkg_config["repo_url"]
     repo_dir = pkg_config["repo_dir"]
     version_to_tag = pkg_config["version_to_tag"]
+    fetch = not args.no_fetch
 
-    if repo_url is None:
-        print(f"No upstream repository configured for '{spack_name}'.", file=sys.stderr)
-        print(f"Known packages: {', '.join(sorted(PACKAGES))}", file=sys.stderr)
-        print("Add an entry to PACKAGES in this script, or specify a known package.", file=sys.stderr)
-        sys.exit(1)
+    os.makedirs(args.output_dir, exist_ok=True)
 
-    # Clone repos
-    clone_if_missing(repo_url, repo_dir)
-    clone_if_missing("https://github.com/eic/containers.git", "containers")
+    def out(filename):
+        return os.path.join(args.output_dir, filename)
+
+    # Clone / update repos
+    clone_or_fetch(repo_url, repo_dir, fetch=fetch)
+    clone_or_fetch("https://github.com/eic/containers", "containers", fetch=fetch)
 
     # Get all upstream tags with dates
-    print(f"Fetching {spack_name} tags from {repo_dir}...")
+    print(f"\nFetching {spack_name} tags from '{repo_dir}' ...")
     upstream_tags_lines = get_tags_with_dates(repo_dir)
-    with open("tags", "w") as f:
+    with open(out("tags"), "w") as f:
         for line in upstream_tags_lines:
-            print(line)
             f.write(line + "\n")
+    print(f"  {len(upstream_tags_lines)} upstream tags found.")
 
     # Build lookup: tag_name -> "tag|date" line
-    upstream_tag_lookup = {}
+    upstream_tag_lookup: dict[str, str] = {}
     for line in upstream_tags_lines:
-        tag, date = line.split("|", 1)
+        tag, _ = line.split("|", 1)
         upstream_tag_lookup[tag] = line
 
-    # Get container tags (all stable tags)
-    print("Fetching container tags...")
+    # Get container stable tags
+    print("\nFetching eic/containers tags ...")
     all_container_lines = get_tags_with_dates("containers")
-    eic_container_tags = []
-    for line in all_container_lines:
-        tag = line.split("|")[0]
-        if "stable" not in tag:
-            continue
-        eic_container_tags.append(line)
-
-    with open("eic_container_tags", "w") as f:
+    eic_container_tags = [
+        line for line in all_container_lines
+        if "stable" in line.split("|")[0]
+    ]
+    with open(out("eic_container_tags"), "w") as f:
         for line in eic_container_tags:
-            print(line)
             f.write(line + "\n")
+    print(f"  {len(eic_container_tags)} stable container tags found.")
 
     # For each container tag, extract the package version and look up its upstream tag date
-    print(f"Extracting {spack_name} versions from container tags...")
+    print(f"\nExtracting {spack_name} versions from container tags ...")
     results = []
+    missing = 0
     for line in eic_container_tags:
         container_tag = line.split("|")[0]
         version = get_package_version("containers", container_tag, spack_name)
         if version is None:
-            print(f"  {container_tag}: {spack_name} version not found", file=sys.stderr)
+            print(
+                f"  WARNING: {container_tag}: {spack_name} not found in spack environment",
+                file=sys.stderr,
+            )
+            missing += 1
             continue
 
         upstream_tag = version_to_tag(version)
         if upstream_tag in upstream_tag_lookup:
             result_line = upstream_tag_lookup[upstream_tag]
             results.append(result_line)
-            print(f"  {container_tag} -> {spack_name} {version}: {result_line}")
+            print(f"  {container_tag} -> {spack_name} {version} ({upstream_tag})")
         else:
-            print(f"  {container_tag} -> {spack_name} {version}: "
-                  f"tag {upstream_tag} not found in {repo_dir} repo",
-                  file=sys.stderr)
+            print(
+                f"  WARNING: {container_tag} -> {spack_name} {version}: "
+                f"tag '{upstream_tag}' not found in '{repo_dir}' repo",
+                file=sys.stderr,
+            )
+            missing += 1
 
-    with open("result", "w") as f:
+    with open(out("result"), "w") as f:
         for line in results:
-            print(line)
             f.write(line + "\n")
 
-    print(f"\nDone. {len(results)} results written.")
+    print(f"\nDone: {len(results)} results written to '{args.output_dir}/result'.")
+    if missing:
+        print(f"  {missing} container tag(s) had no matching upstream tag (see warnings above).")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Phase 1 — Code Review

### Summary

`Infrastructure/Acts_versions/versions.py` is a well-conceived replacement for the old singularity-based shell scripts: it reads spack environment files directly from the eic/containers git history, covering all stable tags without needing running containers. The core logic and three-level YAML fallback are sound. However, several correctness and usability issues were found during review against the current eic/containers repository structure and EIC software stack.

---

### What Works Well

1. **Algorithm is correct**: Reading package versions from git history rather than executing singularity containers is the right approach and covers more tags (including v23.* and v24.02.* that the shell scripts skipped).
2. **Three-level YAML fallback**: The cascade `packages.yaml → spack-environment/dev/spack.yaml → spack.yaml` accurately reflects the historical evolution of eic/containers. Verified against v23.03.0-stable (root `spack.yaml`), v23.05.0-stable (`dev/spack.yaml`), and v24.03.0-stable (`packages.yaml`).
3. **DD4hep tag conversion**: `_dd4hep_version_to_tag` correctly maps spack version `1.35` → git tag `v01-35` and `1.25.1` → `v01-25-01`. Verified against the AIDASoft/DD4hep tag list.
4. **Exact package name matching**: The regex anchors to the start of the spec string, correctly preventing `acts-dd4hep` from matching the `dd4hep` query.
5. **YAML parsing**: Using `yaml.safe_load` is safe and appropriate; the parser correctly strips YAML quoting (e.g., `'@44.4.0'` → Python string `@44.4.0`).

---

### Issues Found

#### Critical

**1. `run()` silently ignores command failures** (Critical)

```python
# BEFORE
def run(cmd, **kwargs):
    result = subprocess.run(cmd, capture_output=True, text=True, **kwargs)
    if result.returncode != 0:
        print(f"Command failed: {' '.join(cmd)}", file=sys.stderr)
        print(result.stderr, file=sys.stderr)
    return result.stdout   # always returns stdout, even on failure
```

The function always returns `result.stdout` regardless of exit code. If `git clone` fails (no network, wrong URL), the script continues silently with an empty or missing repo directory, then crashes later with a confusing error. Callers have no way to detect failure. **Fix**: return the full `CompletedProcess` result so callers can inspect `returncode`.

**2. No `git fetch` for existing repositories** (Critical)

`clone_if_missing()` is a one-time operation: if the repos already exist, no update is performed. Running the script weeks after the initial clone produces stale results that miss new container releases and upstream tags. **Fix**: add `git fetch --tags` when the repo exists, with a `--no-fetch` flag for offline/cached use.

---

#### Major

**3. Contradictory help text for unknown packages** (Major)

The argparse help text reads:
```
Other names will be looked up with v{version} tag convention.
```
But the code immediately `sys.exit(1)` for any package not in `PACKAGES`. The help text implies dynamic support that does not exist. **Fix**: remove the misleading sentence and print a clear error listing known packages.

**4. Regex in `extract_version_from_packages_yaml` unnecessarily complex** (Major)

```python
# BEFORE – confusing: quotes are already stripped by yaml.safe_load
m = re.match(r"'?@([0-9][^']*)'?", entry)
```

After `yaml.safe_load()`, the YAML single-quote delimiters are gone; the Python string is just `@44.4.0`. The `'?` and `[^']*` are therefore no-ops. A cleaner pattern makes the code self-documenting:

```python
# AFTER
version_re = re.compile(r"@([0-9][^\s]*)")
m = version_re.match(entry)
```

**5. No YAML error handling** (Major)

`yaml.safe_load()` raises `yaml.YAMLError` on malformed content (truncated git objects, encoding issues). This exception is unhandled and would crash the entire script mid-run. **Fix**: wrap in `try/except yaml.YAMLError: return None`.

**6. `plot.py` assertion gives unhelpful error** (Major)

```python
assert len(eic_container_tags) == len(result)
```

A bare `AssertionError` gives no diagnosis. **Fix**: raise `ValueError` with a message explaining the mismatch and how to fix it.

**7. `plot.py` has dead code** (Major)

```python
tags = np.array([l.strip().replace("refs/tags/v", "").split("|") for l in fp.readlines()])
```

`git for-each-ref --format=%(refname:short)` already returns short names (`v44.4.0`, not `refs/tags/v44.4.0`), so `.replace("refs/tags/v", "")` is always a no-op. **Fix**: remove it.

---

#### Minor

**8. Only ACTS and DD4hep are pre-configured** (Minor)

Four other core EIC/HEP packages are commonly tracked but missing from `PACKAGES`. Verified correct tag-format mappings against their GitHub repos:

| Spack name | Upstream repo | Tag format | Converter |
|---|---|---|---|
| `eicrecon` | eic/EICrecon | `v1.36.1` | `_identity_version_to_tag` |
| `podio` | AIDASoft/podio | `v01-06` | `_hep_version_to_tag` |
| `edm4hep` | key4hep/EDM4hep | `v00-99-04` | `_hep_version_to_tag` |
| `geant4` | Geant4/geant4 | `v11.3.2` | strip `.east` suffix |

Note: EIC containers currently use `geant4@11.3.2.east` (an EIC-patched build). The `.east` suffix has no upstream tag; the converter strips it and returns the base release tag.

**9. DD4hep `repo_url` has redundant `.git` suffix** (Minor)

`https://github.com/AIDASoft/DD4hep.git` vs. `https://github.com/acts-project/acts` (no `.git`). Cosmetic inconsistency; GitHub accepts both. Fixed for consistency.

**10. Output directory not configurable** (Minor)

Output files are always written to the current working directory. A `--output-dir` flag makes it easy to run for multiple packages without overwriting each other's `tags`/`result` files.

**11. No `--list-packages` convenience flag** (Minor)

Users must read the source to discover available packages. Adding `--list-packages` improves discoverability.

**12. `plot.py` hard-codes `COMPONENT = "DD4hep"`** (Minor)

Now that more packages are supported, `plot.py` should accept `--component` as a command-line argument rather than requiring source edits.

---

## Changes Made

### `Infrastructure/Acts_versions/versions.py`

- **Fix `run()`**: returns `CompletedProcess` result instead of raw stdout; callers inspect `returncode`.
- **Add `clone_or_fetch()`**: clones on first run; runs `git fetch --tags` when repo already exists; exits with clear error if clone fails.
- **Add `--output-dir` / `-o`**: all three output files go to the specified directory.
- **Add `--no-fetch`**: skips `git fetch` for offline / cached runs.
- **Add `--list-packages`**: prints configured packages and their upstream URLs.
- **Add 4 new packages**: `eicrecon` (semver), `podio` (HEP-style), `edm4hep` (HEP-style), `geant4` (with `.east`-stripping converter). Rename `_dd4hep_version_to_tag` → `_hep_version_to_tag` since it applies to all three AIDASoft/key4hep projects.
- **Fix regex**: `r"@([0-9][^\s]*)"` replaces the confusing `r"'?@([0-9][^']*)'?"`.
- **Add `yaml.YAMLError` handling** in both extraction functions.
- **Fix error message**: remove misleading "Other names will be looked up …" text.
- **Update docstring**: accurately describes differences from the shell scripts and documents all flags.
- **Remove noisy per-tag `print()` calls**: replaced with a concise summary line per container tag, keeping informational output without flooding the terminal for 80+ tags.

### `Infrastructure/Acts_versions/plot.py`

- **Add `argparse`**: `--component` (replaces hard-coded `COMPONENT`), `--skip` (replaces hard-coded dict lookup), `--input-dir` (reads from versions.py `--output-dir`), `--output` (figure path).
- **Extract `load_tag_file()` helper**: removes duplicated open/parse/array logic.
- **Remove dead code**: `.replace("refs/tags/v", "")` no-op deleted.
- **Improve assertion**: replaced bare `assert` with `raise ValueError(...)` explaining the mismatch and how to fix it.
- **Extract annotation parameters into `DEFAULT_ANNOTATION_PARAMS` dict**: removes the `if COMPONENT == "Acts": … elif COMPONENT == "DD4hep": …` branching inside the loop.
- **Style**: double-quoted strings, type annotations on public functions, consistent formatting.