### PR TITLE
fix: skip null downstream_pipeline IDs in waterfall script

### DIFF
--- a/waterfall-eicweb.sh
+++ b/waterfall-eicweb.sh
@@ -48,8 +48,9 @@ fetch_pipeline() {
     # Get the bridges, shouldn't be paginated
     bridges_url="$url/$project/pipelines/$pipeline/bridges"
 
-    # Obtain the child pipeline ids
-    child_pipelines=$(curl -LfsS "$bridges_url" | jq -r '.[].downstream_pipeline | "\(.project_id):\(.id)"')
+    # Obtain the child pipeline ids; skip bridges where the child pipeline
+    # has not yet been created (downstream_pipeline is null)
+    child_pipelines=$(curl -LfsS "$bridges_url" | jq -r '.[] | select(.downstream_pipeline != null) | .downstream_pipeline | "\(.project_id):\(.id)"')
 
     # Fetch child pipelines
     for child_pipeline in $child_pipelines; do
@@ -62,10 +63,11 @@ fetch_pipeline() {
 echo "Fetching main pipeline"
 fetch_pipeline "$project:$pipeline"
 
-# Finally output as trace.json
+# Finally output as trace.json; skip jobs with null pipeline id (bridge
+# triggered but child pipeline not yet created when waterfall ran)
 jq \
 'map(['\
-'select(.started_at and .finished_at) | '\
+'select(.started_at and .finished_at and .pipeline.id != null) | '\
 '{name: (.name), cat: "PERF", ph: "B", pid: .pipeline.id, tid: .id, ts: (.started_at | sub("\\.[0-9]+Z$"; "Z") | fromdate * 10e5)},'\
 '{name: (.name), cat: "PERF", ph: "E", pid: .pipeline.id, tid: .id, ts: (.finished_at | sub("\\.[0-9]+Z$"; "Z") | fromdate * 10e5)}'\
 ']) | flatten(1) | .[]' $dir/jobs-*-*.json | jq -s > trace.json


### PR DESCRIPTION
When the `waterfall:upload` job runs before triggered child pipelines have been created, the GitLab bridges API returns `downstream_pipeline: null`. This produced `"null:null"` child pipeline IDs which caused spurious fetch attempts and invalid Perfetto trace entries.

## Fixes

### Null bridge filtering (`fetch_pipeline`)

```diff
-child_pipelines=$(curl -LfsS "$bridges_url" | jq -r '.[].downstream_pipeline | "\(.project_id):\(.id)"')
+child_pipelines=$(curl -LfsS "$bridges_url" | jq -r '.[] | select(.downstream_pipeline != null) | .downstream_pipeline | "\(.project_id):\(.id)"')
```

Bridges where the child pipeline has not yet been created are now silently skipped.

### Null pipeline.id guard in trace output

```diff
-select(.started_at and .finished_at) |
+select(.started_at and .finished_at and .pipeline.id != null) |
```

Jobs whose pipeline reference is null are excluded from the trace JSON so Perfetto never sees a null `pid`.