### PR TITLE
fix: drop .json suffix from mktemp template for BusyBox compatibility

### DIFF
--- a/waterfall-eicweb.sh
+++ b/waterfall-eicweb.sh
@@ -94,7 +94,7 @@ upload_to_pages() {
         | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('sha',''))" 2>/dev/null || true)
 
     # Build the JSON body with Python to avoid shell "Argument list too long" on large traces
-    _body_file=$(mktemp /tmp/gh_upload_XXXXXX.json)
+    _body_file=$(mktemp /tmp/gh_upload_XXXXXX)
     python3 - << PYEOF
 import json, base64
 with open('trace.json', 'rb') as f:


### PR DESCRIPTION
BusyBox `mktemp` (used in Alpine Linux, including the `waterfall:upload` CI job) does not support suffixes after the `X` placeholder sequence. GNU `mktemp` accepts trailing non-X characters as an implicit `--suffix`, but BusyBox rejects the template and prints `mktemp: : Invalid argument`, leaving `$_body_file` empty. This caused the subsequent `python3` `open()` call and `curl -d @"$_body_file"` to fail with:

```
mktemp: : Invalid argument
FileNotFoundError: [Errno 2] No such file or directory: ''
curl: Failed to open
```

**Fix:** remove the `.json` suffix — the extension is cosmetic and not required for correctness.