### PR TITLE
fix: preserve original pipeline ID for upload filename

### DIFF
--- a/waterfall-eicweb.sh
+++ b/waterfall-eicweb.sh
@@ -60,6 +60,7 @@ fetch_pipeline() {
 
 }
 
+main_pipeline="$pipeline"
 echo "Fetching main pipeline"
 fetch_pipeline "$project:$pipeline"
 
@@ -137,5 +138,5 @@ PYEOF
 }
 
 if [ "$PAGES" = "1" ]; then
-    upload_to_pages "$pipeline"
+    upload_to_pages "$main_pipeline"
 fi


### PR DESCRIPTION
## Problem

`fetch_pipeline` overwrites the global `$pipeline` variable (POSIX `sh` has no function-local scoping). After recursively fetching all child pipelines, `$pipeline` holds the **last child pipeline ID** instead of the root/main pipeline ID passed by the user.

This caused the trace to be uploaded as e.g. `traces/trace-143223.json` instead of the correct `traces/trace-143214.json`.

## Fix

Save `$pipeline` into `$main_pipeline` before calling `fetch_pipeline`, then pass `$main_pipeline` to `upload_to_pages`.